### PR TITLE
Disable text selection on puzzle cells

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@ body{font-family:Arial,Helvetica,sans-serif;margin:20px;font-size:18px;display:f
 #board{margin-top:20px;}
 #game,#result{display:none;}
 table{border-collapse:collapse;}
-td,th{border:1px solid #555;width:40px;height:40px;text-align:center;font-size:1.2em;}
+td,th{border:1px solid #555;width:40px;height:40px;text-align:center;font-size:1.2em;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;}
 td.sum{background:#f0f0f0;font-weight:bold;}
 td.mark-correct{background:#8f8;}
 td.mark-wrong{background:#f88;}


### PR DESCRIPTION
## Summary
- prevent table cell text from being highlighted when interacting with the puzzle board

## Testing
- `grep -n "user-select" -n index.html`

------
https://chatgpt.com/codex/tasks/task_b_68433c734e1c8326a7b9f7f27f72758f