### PR TITLE
Add seed display during gameplay

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Open `index.html` in any modern web browser. No build step or server is required
 1. On the start screen choose the grid width, height, difficulty level and an optional seed.
 2. Press **Start Puzzle** to generate and play.
 3. Click a cell to cycle between unmarked, marked as correct (green) and marked as incorrect (red).
-4. When every cell is marked and all correct numbers are identified the timer stops and a result screen is shown.
-5. From the result screen you can start a new puzzle.
+4. The seed for the puzzle is displayed under the board so you can note it while playing.
+5. When every cell is marked and all correct numbers are identified the timer stops and a result screen is shown.
+6. From the result screen you can start a new puzzle.
 
 The puzzle generation uses a seeded pseudo random generator so the same seed and settings will recreate the same puzzle.

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@ td.mark-wrong{background:#f88;}
 .mini td,.mini th{width:30px;height:30px;font-size:14px;}
 #titleRow{display:flex;flex-direction:column;gap:10px;align-items:center;justify-content:center;}
 #titleRow .description{margin:0;}
+.subtext{font-size:0.8em;color:#555;margin-top:5px;}
 @media (max-width:600px){
  td,th{width:32px;height:32px;font-size:1em;}
  .mini td,.mini th{width:24px;height:24px;font-size:12px;}
@@ -44,6 +45,7 @@ td.mark-wrong{background:#f88;}
 <div id="game">
 <div>Time: <span id="timer">0s</span></div>
 <div id="board"></div>
+<div id="seedInfo" class="subtext"></div>
 </div>
 <div id="result">
 <h2>Puzzle Completed!</h2>
@@ -127,6 +129,7 @@ const seedStr=document.getElementById('seedInput').value;
 let seed=0;
 if(seedStr){for(let i=0;i<seedStr.length;i++)seed+=seedStr.charCodeAt(i);}else{seed=Math.floor(Math.random()*1000000);}
  puzzle=generateUniquePuzzle(width,height,difficulty,seed);
+ document.getElementById('seedInfo').textContent='Seed: '+puzzle.seed;
  renderBoard();
  document.getElementById('start').style.display='none';
  document.getElementById('game').style.display='block';
@@ -225,6 +228,7 @@ document.getElementById('startBtn').addEventListener('click',startGame);
 document.getElementById('playAgain').addEventListener('click',()=>{
  document.getElementById('result').style.display='none';
  document.getElementById('start').style.display='block';
+ document.getElementById('seedInfo').textContent='';
  marks=[];
 });
 </script>


### PR DESCRIPTION
## Summary
- show puzzle seed while playing so players can note it
- document seed display in README

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_b_68455961a03483269ecdf32130051e3b