### PR TITLE
Fix sum description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sum Puzzle Game
 
-This repository contains a simple HTML/JavaScript puzzle game. The goal is to mark the digits that contribute to the sums shown on the right and bottom edges of the grid.
+This repository contains a simple HTML/JavaScript puzzle game. The goal is to mark the digits that contribute to the sums shown on the left and top edges of the grid.
 
 ## Running
 Open `index.html` in any modern web browser. No build step or server is required.

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@ td.mark-wrong{background:#f88;}
 <body>
 <div id="titleRow">
 <h1>Sum Puzzle</h1>
-<p class="description">Mark the digits that contribute to the sums on the right and bottom. Toggle a cell to cycle between green if you think it belongs to the sum and red if you think it does not, until all correct numbers are found.</p>
+<p class="description">Mark the digits that contribute to the sums on the left and top. Toggle a cell to cycle between green if you think it belongs to the sum and red if you think it does not, until all correct numbers are found.</p>
 </div>
 <div id="start">
 <label>X size:<input id="widthInput" type="number" value="5" min="1"></label><br>


### PR DESCRIPTION
## Summary
- clarify that puzzle sums appear on the left and top

## Testing
- `grep -n "left and top" README.md`
- `grep -n "left and top" index.html`

------
https://chatgpt.com/codex/tasks/task_b_68455b30e0248326a36c0ee8ceeb24cb